### PR TITLE
spike amplitudes: display y-axiseven when no units are selected

### DIFF
--- a/src/extensions/spikeamplitudes/SpikeAmplitudesView/SpikeAmplitudesPanel.ts
+++ b/src/extensions/spikeamplitudes/SpikeAmplitudesView/SpikeAmplitudesPanel.ts
@@ -27,7 +27,7 @@ class SpikeAmplitudesPanel {
     _globalAmplitudeRange: {min: number, max: number} | null = null
     _includeZero = true
     _amplitudes: number[] | undefined = undefined
-    constructor(private args: {spikeAmplitudesData: SpikeAmplitudesData, recording: Recording, sorting: Sorting, unitId: number, hither: HitherInterface}) {
+    constructor(private args: {spikeAmplitudesData: SpikeAmplitudesData | null, recording: Recording, sorting: Sorting, unitId: number, hither: HitherInterface}) {
     }
     setTimeRange(timeRange: {min: number, max: number}) {
         this._timeRange = timeRange
@@ -39,6 +39,7 @@ class SpikeAmplitudesPanel {
         const color = colorForUnitId(this.args.unitId)
         const pen: Pen = {color: 'black'}
         const brush: Brush = {color}
+        if (!this.args.spikeAmplitudesData) return
         const result = this.args.spikeAmplitudesData.getSpikeAmplitudes(this.args.unitId)
         if ((result) && (result.timepoints) && (result.amplitudes)) {
             const { timepoints, amplitudes } = result

--- a/src/extensions/spikeamplitudes/SpikeAmplitudesView/SpikeAmplitudesTimeWidget.tsx
+++ b/src/extensions/spikeamplitudes/SpikeAmplitudesView/SpikeAmplitudesTimeWidget.tsx
@@ -42,6 +42,16 @@ const SpikeAmplitudesTimeWidget: FunctionComponent<Props> = ({ spikeAmplitudesDa
             }
             panels.push(p)
         })
+        // we want the y-axis to show even when no units are selected
+        if (panels.length === 0) {
+            panels.push(new SpikeAmplitudesPanel({
+                spikeAmplitudesData: null,
+                recording,
+                sorting,
+                unitId: -1,
+                hither
+            }))
+        }
         if (allMins.length > 0) {
             panels.forEach(p => {
                 p.setGlobalAmplitudeRange({min: getArrayMin(allMins), max: getArrayMax(allMaxs)})


### PR DESCRIPTION
Fixes #380