### PR TITLE
handle case where all electrodes have same coordinate, eg (0, 0)

### DIFF
--- a/src/extensions/WorkspaceView/RecordingInfoView.tsx
+++ b/src/extensions/WorkspaceView/RecordingInfoView.tsx
@@ -1,23 +1,23 @@
 // convert to tsx
 import { Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core';
-import React, { FunctionComponent, useMemo, useState } from 'react';
+import React, { FunctionComponent, useMemo, useReducer } from 'react';
 import { Electrode } from '../devel/ElectrodeGeometryTest/ElectrodeGeometry';
 import ElectrodeGeometryWidget from '../electrodegeometry/ElectrodeGeometryWidget/ElectrodeGeometryWidget';
-import { RecordingInfo } from '../extensionInterface';
+import { RecordingInfo, recordingSelectionReducer } from '../extensionInterface';
 
 
 const zipElectrodes = (locations: number[][], ids: number[]): Electrode[] => {
     if (locations && ids && ids.length !== locations.length) throw Error('Electrode ID count does not match location count.')
     return ids.map((x: number, index: number) => {
         const loc = locations[index]
-        return { label: x + '', x: loc[0], y: loc[1] }
+        return { label: x + '', x: loc[0], y: loc[1], id: x }
     })
 }
 
 const RecordingInfoView: FunctionComponent<{recordingInfo: RecordingInfo, hideElectrodeGeometry: boolean}> = ({ recordingInfo, hideElectrodeGeometry }) => {
     const ri = recordingInfo;
     const electrodes = useMemo(() => (ri ? zipElectrodes(ri.geom, ri.channel_ids) : []), [ri])
-    const [selectedElectrodeIds, setSelectedElectrodeIds] = useState<number[]>([]);
+    const [selection, selectionDispatch] = useReducer(recordingSelectionReducer, {})
     if (!ri) {
         return (
             <div>No recording info found for recording.</div>
@@ -38,8 +38,8 @@ const RecordingInfoView: FunctionComponent<{recordingInfo: RecordingInfo, hideEl
                 !hideElectrodeGeometry && (
                     <ElectrodeGeometryWidget
                         electrodes={electrodes}
-                        selectedElectrodeIds={selectedElectrodeIds}
-                        onSelectedElectrodeIdsChanged={setSelectedElectrodeIds}
+                        selection={selection}
+                        selectionDispatch={selectionDispatch}
                         width={350}
                         height={150}
                     />

--- a/src/extensions/averagewaveforms/AverageWaveformsView/WaveformWidget.tsx
+++ b/src/extensions/averagewaveforms/AverageWaveformsView/WaveformWidget.tsx
@@ -25,16 +25,18 @@ export type ElectrodeOpts = {
     colors?: ElectrodeColors
     showLabels?: boolean
     disableSelection?: boolean
+    maxElectrodePixelRadius?: number
 }
 
 export type LayerProps = Props & {
     layoutMode: 'geom' | 'vertical'
-    electrodeOpts: ElectrodeOpts
     waveformOpts: {
         colors?: WaveformColors
         waveformWidth: number
     }
 }
+
+export type ElectrodeLayerProps = Props
 
 const electrodeColors: ElectrodeColors = {
     border: 'rgb(120, 100, 120)',
@@ -68,7 +70,11 @@ const WaveformWidget: FunctionComponent<Props> = (props) => {
         electrodeOpts: {...defaultElectrodeOpts, ...props.electrodeOpts},
         waveformOpts: defaultWaveformOpts,
     }
-    const electrodesLayer = useLayer(createElectrodesLayer, layerProps)
+    const electrodeLayerProps: ElectrodeLayerProps = {
+        ...props,
+        electrodeOpts: {...defaultElectrodeOpts, ...props.electrodeOpts},
+    }
+    const electrodesLayer = useLayer(createElectrodesLayer, electrodeLayerProps)
     const waveformLayer = useLayer(createWaveformLayer, layerProps)
     const layers = useLayers([electrodesLayer, waveformLayer])
     return (

--- a/src/extensions/averagewaveforms/AverageWaveformsView/electrodesLayer.ts
+++ b/src/extensions/averagewaveforms/AverageWaveformsView/electrodesLayer.ts
@@ -2,7 +2,7 @@ import { CanvasPainter } from '../../common/CanvasWidget/CanvasPainter';
 import { CanvasDragEvent, CanvasWidgetLayer, ClickEvent, ClickEventType, DiscreteMouseEventHandler, DragHandler } from "../../common/CanvasWidget/CanvasWidgetLayer";
 import { pointIsInEllipse, RectangularRegion, rectangularRegionsIntersect } from '../../common/CanvasWidget/Geometry';
 import setupElectrodes, { ElectrodeBox } from './setupElectrodes';
-import { LayerProps } from './WaveformWidget';
+import { ElectrodeLayerProps } from './WaveformWidget';
 
 export type ElectrodeColors = {
     border: string,
@@ -46,7 +46,7 @@ const defaultColors: ElectrodeColors = {
     textDark: 'rgb(32, 32, 32)'
 }
 
-const handleClick: DiscreteMouseEventHandler = (event: ClickEvent, layer: CanvasWidgetLayer<LayerProps, LayerState>) => {
+const handleClick: DiscreteMouseEventHandler = (event: ClickEvent, layer: CanvasWidgetLayer<ElectrodeLayerProps, LayerState>) => {
     if (event.type !== ClickEventType.Release) return
     const { selectionDispatch, electrodeOpts: opts } = layer.getProps()
     if (opts.disableSelection) return
@@ -77,7 +77,7 @@ const handleClick: DiscreteMouseEventHandler = (event: ClickEvent, layer: Canvas
     layer.scheduleRepaint()
 }
 
-const handleHover: DiscreteMouseEventHandler = (event: ClickEvent, layer: CanvasWidgetLayer<LayerProps, LayerState>) => {
+const handleHover: DiscreteMouseEventHandler = (event: ClickEvent, layer: CanvasWidgetLayer<ElectrodeLayerProps, LayerState>) => {
     if (event.type !== ClickEventType.Move) return
     const state = layer.getState()
     if (state === null) return
@@ -86,7 +86,7 @@ const handleHover: DiscreteMouseEventHandler = (event: ClickEvent, layer: Canvas
     layer.scheduleRepaint()
 }
 
-const handleDragSelect: DragHandler = (layer: CanvasWidgetLayer<LayerProps, LayerState>, drag: CanvasDragEvent) => {
+const handleDragSelect: DragHandler = (layer: CanvasWidgetLayer<ElectrodeLayerProps, LayerState>, drag: CanvasDragEvent) => {
     const state = layer.getState()
     const { selectionDispatch, electrodeOpts: opts } = layer.getProps()
     if (opts.disableSelection) return
@@ -103,7 +103,7 @@ const handleDragSelect: DragHandler = (layer: CanvasWidgetLayer<LayerProps, Laye
 }
 
 export const createElectrodesLayer = () => {
-    const onPaint = (painter: CanvasPainter, props: LayerProps, state: LayerState) => {
+    const onPaint = (painter: CanvasPainter, props: ElectrodeLayerProps, state: LayerState) => {
         const opts = props.electrodeOpts
         const colors = opts.colors || defaultColors
         const showLabels = opts.showLabels
@@ -149,15 +149,15 @@ export const createElectrodesLayer = () => {
         
         state.dragRegion && painter.fillRect(state.dragRegion, {color: colors.dragRect})
     }
-    const onPropsChange = (layer: CanvasWidgetLayer<LayerProps, LayerState>, props: LayerProps) => {
+    const onPropsChange = (layer: CanvasWidgetLayer<ElectrodeLayerProps, LayerState>, props: ElectrodeLayerProps) => {
         const state = layer.getState()
         const { width, height, electrodeLocations, electrodeIds, layoutMode } = props
-        const { electrodeBoxes, transform, radius, pixelRadius } = setupElectrodes({width, height, electrodeLocations, electrodeIds, layoutMode})
+        const { electrodeBoxes, transform, radius, pixelRadius } = setupElectrodes({width, height, electrodeLocations, electrodeIds, layoutMode, maxElectrodePixelRadius: props.electrodeOpts.maxElectrodePixelRadius})
         layer.setTransformMatrix(transform)
         layer.setState({...state, electrodeBoxes, radius, pixelRadius})
         layer.scheduleRepaint()
     }
-    return new CanvasWidgetLayer<LayerProps, LayerState>(
+    return new CanvasWidgetLayer<ElectrodeLayerProps, LayerState>(
         onPaint,
         onPropsChange,
         initialLayerState,

--- a/src/extensions/averagewaveforms/AverageWaveformsView/setupElectrodes.ts
+++ b/src/extensions/averagewaveforms/AverageWaveformsView/setupElectrodes.ts
@@ -127,21 +127,21 @@ const setupElectrodes = (args: {width: number, height: number, electrodeLocation
     if (layoutMode === 'vertical') {
         return setupVerticalElectrodes({width, height, electrodeIds})
     }
-    const electrodeLocations2 = fixDegenerateCase(electrodeLocations)
+    const correctedElectrodeLocations = fixDegenerateCase(electrodeLocations)
     const W = width - 10 * 2
     const H = height - 10 * 2
     const canvasAspect = W / H
 
-    const radius = computeRadius(electrodeLocations2)
-    let boundingBox = getElectrodesBoundingBox(electrodeLocations2, radius)
+    const radius = computeRadius(correctedElectrodeLocations)
+    let boundingBox = getElectrodesBoundingBox(correctedElectrodeLocations, radius)
     let boxAspect = getWidth(boundingBox) / getHeight(boundingBox)
 
-    let realizedElectrodeLocations = electrodeLocations2
+    let realizedElectrodeLocations = correctedElectrodeLocations
     if ((boxAspect > 1) !== (canvasAspect > 1)) {
         // if the two aspect ratios' relationship to 1 is different, then one is portrait
         // and the other landscape. We should then correct by rotating the electrode set 90 degrees.
-        // note: a 90-degree right rotation in 2d makes x' = y and y' = -x
-        realizedElectrodeLocations = electrodeLocations2.map((loc) => {
+        // note: a 90-degree rotation around the origin makes x' = y and y' = -x
+        realizedElectrodeLocations = correctedElectrodeLocations.map((loc) => {
             return [loc[1], -loc[0]]
         })
         // and of course that also means resetting the x- and y-ranges of the bounding box.

--- a/src/extensions/averagewaveforms/AverageWaveformsView/setupElectrodes.ts
+++ b/src/extensions/averagewaveforms/AverageWaveformsView/setupElectrodes.ts
@@ -102,7 +102,22 @@ const setupVerticalElectrodes = ({width, height, electrodeIds}: {width: number, 
     }
 }
 
-const setupElectrodes = (args: {width: number, height: number, electrodeLocations: Vec2[], electrodeIds: number[], layoutMode: 'geom' | 'vertical'}): {
+const fixDegenerateCase = (electrodeLocations: Vec2[]) => {
+    const box = {
+        xmin: getArrayMin(electrodeLocations.map(e => (e[0]))),
+        xmax: getArrayMax(electrodeLocations.map(e => (e[0]))),
+        ymin: getArrayMin(electrodeLocations.map(e => (e[1]))),
+        ymax: getArrayMax(electrodeLocations.map(e => (e[1])))
+    }
+    if ((box.xmin === box.xmax) && (box.ymin === box.ymax)) {
+        return electrodeLocations.map((x, ii) => [ii, 0])
+    }
+    else {
+        return electrodeLocations
+    }
+}
+
+const setupElectrodes = (args: {width: number, height: number, electrodeLocations: Vec2[], electrodeIds: number[], layoutMode: 'geom' | 'vertical', maxElectrodePixelRadius?: number}): {
     electrodeBoxes: ElectrodeBox[],
     transform: TransformationMatrix,
     radius: number,
@@ -112,20 +127,21 @@ const setupElectrodes = (args: {width: number, height: number, electrodeLocation
     if (layoutMode === 'vertical') {
         return setupVerticalElectrodes({width, height, electrodeIds})
     }
+    const electrodeLocations2 = fixDegenerateCase(electrodeLocations)
     const W = width - 10 * 2
     const H = height - 10 * 2
     const canvasAspect = W / H
 
-    const radius = computeRadius(electrodeLocations)
-    let boundingBox = getElectrodesBoundingBox(electrodeLocations, radius)
+    const radius = computeRadius(electrodeLocations2)
+    let boundingBox = getElectrodesBoundingBox(electrodeLocations2, radius)
     let boxAspect = getWidth(boundingBox) / getHeight(boundingBox)
 
-    let realizedElectrodeLocations = electrodeLocations
+    let realizedElectrodeLocations = electrodeLocations2
     if ((boxAspect > 1) !== (canvasAspect > 1)) {
         // if the two aspect ratios' relationship to 1 is different, then one is portrait
         // and the other landscape. We should then correct by rotating the electrode set 90 degrees.
         // note: a 90-degree right rotation in 2d makes x' = y and y' = -x
-        realizedElectrodeLocations = electrodeLocations.map((loc) => {
+        realizedElectrodeLocations = electrodeLocations2.map((loc) => {
             return [loc[1], -loc[0]]
         })
         // and of course that also means resetting the x- and y-ranges of the bounding box.
@@ -141,6 +157,13 @@ const setupElectrodes = (args: {width: number, height: number, electrodeLocation
     else {
         // we are constrained in height
         scaleFactor = H / getHeight(boundingBox)
+    }
+
+    // don't allow the electrodes to appear too big
+    if (args.maxElectrodePixelRadius) {
+        if (radius * scaleFactor > args.maxElectrodePixelRadius) {
+            scaleFactor /= (radius * scaleFactor / args.maxElectrodePixelRadius)
+        }
     }
 
     const xMargin = (width - getWidth(boundingBox) * scaleFactor) / 2

--- a/src/extensions/averagewaveforms/AverageWaveformsView/waveformLayer.ts
+++ b/src/extensions/averagewaveforms/AverageWaveformsView/waveformLayer.ts
@@ -60,7 +60,7 @@ export const createWaveformLayer = () => {
     }
     const onPropsChange = (layer: CanvasWidgetLayer<LayerProps, LayerState>, props: LayerProps) => {
         const { width, height, electrodeLocations, electrodeIds } = props
-        const { electrodeBoxes, transform } = setupElectrodes({width, height, electrodeLocations, electrodeIds, layoutMode: props.layoutMode})
+        const { electrodeBoxes, transform } = setupElectrodes({width, height, electrodeLocations, electrodeIds, layoutMode: props.layoutMode, maxElectrodePixelRadius: props.electrodeOpts.maxElectrodePixelRadius})
         layer.setTransformMatrix(transform)
         layer.setState({electrodeBoxes})
         layer.scheduleRepaint()

--- a/src/extensions/devel/ElectrodeGeometryTest/DragLayer.ts
+++ b/src/extensions/devel/ElectrodeGeometryTest/DragLayer.ts
@@ -18,7 +18,7 @@ const getElectrodeBoundingRect = (e: Electrode, r: number, fill: boolean = false
 
 export interface DragLayerState {
     dragRegion: RectangularRegion | null
-    electrodeBoundingBoxes: {label: string, x: number, y: number, br: RectangularRegion}[]
+    electrodeBoundingBoxes: {label: string, x: number, y: number, id: number, br: RectangularRegion}[]
     selectedElectrodes: Electrode[]
     draggedElectrodes: Electrode[]
 }

--- a/src/extensions/devel/ElectrodeGeometryTest/ElectrodeGeometry.tsx
+++ b/src/extensions/devel/ElectrodeGeometryTest/ElectrodeGeometry.tsx
@@ -10,6 +10,7 @@ import { DragLayerState, paintDragLayer, setDragLayerStateFromProps, updateDragR
 import { paintTestLayer } from './ElectrodeGeometryLayer'
 
 export type Electrode = {
+    id: number,
     label: string,
     x: number,
     y: number

--- a/src/extensions/devel/ElectrodeGeometryTest/ElectrodeGeometryTest.tsx
+++ b/src/extensions/devel/ElectrodeGeometryTest/ElectrodeGeometryTest.tsx
@@ -6,6 +6,7 @@ interface Props {
 
 const ElectrodeGeometryTest = (props: Props) => {
     const electrodes = [[20, 20], [40, 40], [60, 100], [80, 120]].map((coords, ii) => ({
+        id: ii,
         label: ii + '',
         x: coords[0],
         y: coords[1]         

--- a/src/extensions/electrodegeometry/ElectrodeGeometryWidget/ElectrodeGeometryWidget.tsx
+++ b/src/extensions/electrodegeometry/ElectrodeGeometryWidget/ElectrodeGeometryWidget.tsx
@@ -1,8 +1,10 @@
-import React from "react"
-import CanvasWidget from '../../common/CanvasWidget/CanvasWidget'
+import React, { useMemo } from "react"
+import { createElectrodesLayer } from "../../averagewaveforms/AverageWaveformsView/electrodesLayer"
+import { ElectrodeLayerProps } from "../../averagewaveforms/AverageWaveformsView/WaveformWidget"
+import CanvasWidget from "../../common/CanvasWidget"
 import { useLayer, useLayers } from "../../common/CanvasWidget/CanvasWidgetLayer"
-import { Electrode } from "../../devel/ElectrodeGeometryTest/ElectrodeGeometry"
-import { createElectrodeGeometryLayer, ElectrodeLayerProps } from './electrodeGeometryLayer'
+import { RecordingSelection, RecordingSelectionDispatch } from "../../extensionInterface"
+import { Electrode } from "./electrodeGeometryLayer"
 
 // Okay, so after some hoop-jumping, we've learned the RecordingInfo has:
 // - sampling frequency (number), - channel_ids (list of number),
@@ -11,30 +13,35 @@ import { createElectrodeGeometryLayer, ElectrodeLayerProps } from './electrodeGe
 
 interface WidgetProps {
     electrodes: Electrode[] // Note: these shouldn't be interacted with directly. Use the bounding boxes in the state, instead.
-    selectedElectrodeIds: number[]
-    onSelectedElectrodeIdsChanged: (x: number[]) => void
+    selection: RecordingSelection
+    selectionDispatch: RecordingSelectionDispatch
     width: number
     height: number
 }
 
-const ElectrodeGeometryCanvas = (props: ElectrodeLayerProps) => {
-    const layer = useLayer(createElectrodeGeometryLayer, props)
+const ElectrodeGeometryWidget = (props: WidgetProps) => {
+    const electrodeLayerProps: ElectrodeLayerProps = useMemo(() => ({
+        layoutMode: 'geom',
+        electrodeIds: props.electrodes.map(e => e.id),
+        electrodeLocations: props.electrodes.map(e => [e.x, e.y]),
+        width: props.width,
+        height: props.height,
+        selection: props.selection,
+        selectionDispatch: props.selectionDispatch,
+        electrodeOpts: {
+            showLabels: true,
+            maxElectrodePixelRadius: 25
+        },
+        noiseLevel: 0, // not needed
+        samplingFrequency: 0 // not needed
+    }), [props])
+    const layer = useLayer(createElectrodesLayer, electrodeLayerProps)
     const layers = useLayers([layer])
     return (
         <CanvasWidget
             key='electrodeGeometryCanvas'
             layers={layers}
             {...{width: props.width, height: props.height}}
-        />
-    )
-}
-
-
-// Widget proper: just a Sizeme wrapper.
-const ElectrodeGeometryWidget = (props: WidgetProps) => {
-    return (
-        <ElectrodeGeometryCanvas 
-            {...props}
         />
     )
 }

--- a/src/extensions/electrodegeometry/ElectrodeGeometryWidget/electrodeGeometryLayer.ts
+++ b/src/extensions/electrodegeometry/ElectrodeGeometryWidget/electrodeGeometryLayer.ts
@@ -25,6 +25,7 @@ const TextColor = {
 }
 
 export type Electrode = {
+    id: number
     label: string,
     x: number,
     y: number,

--- a/src/extensions/electrodegeometry/electrodegeometry.tsx
+++ b/src/extensions/electrodegeometry/electrodegeometry.tsx
@@ -35,8 +35,8 @@ const ElectrodeGeometryRecordingView: FunctionComponent<RecordingViewProps> = ({
     return (
         <ElectrodeGeometryWidget
             electrodes={electrodes}
-            selectedElectrodeIds={selectedElectrodeIds}
-            onSelectedElectrodeIdsChanged={handleSelectedElectrodeIdsChanged}
+            selection={selection}
+            selectionDispatch={selectionDispatch}
             width={width || 350}
             height={height || 150}
         />

--- a/src/extensions/firetrack/FireTrackView/FireTrackWidget.tsx
+++ b/src/extensions/firetrack/FireTrackView/FireTrackWidget.tsx
@@ -61,7 +61,7 @@ const FireTrackWidget: FunctionComponent<{recording: Recording, timeseriesData: 
             const adjustedVal = - val * scaleFactor
             return valToColor(adjustedVal)
         }
-        return (ri ? zipElectrodes(ri.geom, ri.channel_ids) : []).map(e => ({...e, color: colorForElectrode(e.electrodeId)}))
+        return (ri ? zipElectrodes(ri.geom, ri.channel_ids) : []).map(e => ({...e, id: e.electrodeId, color: colorForElectrode(e.electrodeId)}))
     }, [ri, data, selection.ampScaleFactor])
     const layerProps: ElectrodeLayerProps = {
         electrodes,

--- a/src/extensions/timeseries/TimeseriesViewNew/ElectrodeGeometryView.tsx
+++ b/src/extensions/timeseries/TimeseriesViewNew/ElectrodeGeometryView.tsx
@@ -1,29 +1,20 @@
-import React, { FunctionComponent, useCallback, useMemo, useState } from 'react';
+import React, { FunctionComponent, useMemo } from 'react';
 import ElectrodeGeometryWidget from "../../electrodegeometry/ElectrodeGeometryWidget/ElectrodeGeometryWidget";
-import { RecordingInfo } from "../../extensionInterface";
+import { RecordingInfo, RecordingSelection, RecordingSelectionDispatch } from "../../extensionInterface";
 
 
 interface Props {
     recordingInfo: RecordingInfo
     width: number
     height: number
-    selectedElectrodeIds?: number[]
+    selection: RecordingSelection
+    selectionDispatch: RecordingSelectionDispatch
     visibleElectrodeIds: number[]
-    onSelectedElectrodeIdsChanged?: (s: number[]) => void
 }
 
-const ElectrodeGeometryView: FunctionComponent<Props> = ({recordingInfo, width, height, selectedElectrodeIds, visibleElectrodeIds, onSelectedElectrodeIdsChanged}) => {
+const ElectrodeGeometryView: FunctionComponent<Props> = ({recordingInfo, width, height, selection, visibleElectrodeIds, selectionDispatch}) => {
     const ri = recordingInfo
     const electrodes = useMemo(() => (ri ? zipElectrodes(ri.geom, ri.channel_ids) : []).filter(a => (visibleElectrodeIds.includes(a.id))), [ri, visibleElectrodeIds])
-    const [internalSelectedElectrodeIds, setInternalSelectedElectrodeIds] = useState<number[]>([]);
-    const handleSelectedElectrodeIdsChanged = useCallback((x: number[]) => {
-        if (selectedElectrodeIds) {
-            if (onSelectedElectrodeIdsChanged) onSelectedElectrodeIdsChanged(x);
-        }
-        else {
-            setInternalSelectedElectrodeIds(x)
-        }
-    }, [selectedElectrodeIds, onSelectedElectrodeIdsChanged, setInternalSelectedElectrodeIds])
     if (!ri) {
         return (
             <div>No recording info found for recording.</div>
@@ -32,8 +23,8 @@ const ElectrodeGeometryView: FunctionComponent<Props> = ({recordingInfo, width, 
     return (
         <ElectrodeGeometryWidget
             electrodes={electrodes}
-            selectedElectrodeIds={selectedElectrodeIds ? selectedElectrodeIds : internalSelectedElectrodeIds}
-            onSelectedElectrodeIdsChanged={handleSelectedElectrodeIdsChanged}
+            selection={selection}
+            selectionDispatch={selectionDispatch}
             width={width}
             height={height}
         />

--- a/src/extensions/timeseries/TimeseriesViewNew/TimeseriesViewNew.tsx
+++ b/src/extensions/timeseries/TimeseriesViewNew/TimeseriesViewNew.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useReducer } from 'react';
+import React, { useMemo, useReducer } from 'react';
 import Splitter from '../../common/Splitter';
 import { RecordingInfo, RecordingSelection, RecordingSelectionDispatch, recordingSelectionReducer } from '../../extensionInterface';
 import ElectrodeGeometryView from './ElectrodeGeometryView';
@@ -46,10 +46,6 @@ const TimeseriesViewNew = (props: Props) => {
 
     const y_scale_factor = 1 / (props.recordingInfo.noise_level || 1) * 1/10
 
-    const handleSelectedElectrodeIdsChanged = useCallback((x: number[]) => {
-        recordingSelectionDispatch({type: 'SetSelectedElectrodeIds', selectedElectrodeIds: x})
-    }, [recordingSelectionDispatch])
-
     if (timeseriesData) {
         return (
             <div>
@@ -65,8 +61,8 @@ const TimeseriesViewNew = (props: Props) => {
                                 width={0} // filled in above
                                 height={0} // filled in above
                                 visibleElectrodeIds={visibleElectrodeIds}
-                                selectedElectrodeIds={selectedElectrodeIds}
-                                onSelectedElectrodeIdsChanged={handleSelectedElectrodeIdsChanged}
+                                selection={recordingSelection}
+                                selectionDispatch={recordingSelectionDispatch}
                             />
                         )
                     }


### PR DESCRIPTION
Fixes #292

@jsoules. This started out as a simple fix to the degenerate case of all electrodes having the same coordinates. But then I found that ElectrodeGeometryWidget did not use the same code as the other widgets. So then it took some work to get that to use the same layers. That's why there are little adjustments to the types throughout. Nothing major.