### PR TITLE
apply merges functionality

### DIFF
--- a/python/labbox_ephys/__init__.py
+++ b/python/labbox_ephys/__init__.py
@@ -15,7 +15,7 @@ from .helpers.get_unit_waveforms import get_unit_waveforms
 from .helpers.prepare_snippets_h5 import (prepare_snippets_h5,
                                           prepare_snippets_h5_from_extractors)
 from .helpers.SubsampledSortingExtractor import SubsampledSortingExtractor
-from .misc import get_recording_info, get_recording_object, get_sorting_info
+from .misc import get_recording_info, get_recording_object, get_sorting_info, get_unit_waveforms_from_snippets_h5
 from .register_views import (_recording_views, register_recording_view,
                              register_sorting_view, _sorting_views)
 from .sorters import sorters

--- a/python/labbox_ephys/misc/__init__.py
+++ b/python/labbox_ephys/misc/__init__.py
@@ -5,3 +5,4 @@ from .get_sorting_info import get_sorting_info
 from .calculate_timeseries_info import calculate_timeseries_info
 from .get_timeseries_segment import get_timeseries_segment
 from .get_similar_units import get_similar_units
+from .get_unit_waveforms_from_snippets_h5 import get_unit_waveforms_from_snippets_h5

--- a/python/labbox_ephys/misc/get_unit_waveforms_from_snippets_h5.py
+++ b/python/labbox_ephys/misc/get_unit_waveforms_from_snippets_h5.py
@@ -5,6 +5,11 @@ import numpy as np
 import h5py
 
 def _intersect_channel_ids(channel_ids_list: List[List[int]]):
+    # from js:
+    #   channel_ids_list is a list of the channel IDs that make up the neighborhood for each unit. This function will be passed a set of unit IDs that are to be merged, along with their respective channel neighborhoods. Its job is to reduce that list to only those channels in the neighborhood of each of the underlying units.
+    #   It is assumed that there will be at least one channel common to all units being merged (so that x in line 10 never collapses to an empty list); violating this assumption leads to failure of the function.
+    #   inds will actually wind up being a list of lists--the per-unit-neighborhood indices of the channels in the consolidated/fully intersected set of channels. Like the input channel_ids_list, its outermost index will be the units, so the channel indices can always be mapped back to the units whose neighborhoods they're identifiying.
+    
     x = channel_ids_list[0]
     for y in channel_ids_list:
         x = np.intersect1d(x, y).tolist()

--- a/python/labbox_ephys/misc/get_unit_waveforms_from_snippets_h5.py
+++ b/python/labbox_ephys/misc/get_unit_waveforms_from_snippets_h5.py
@@ -1,0 +1,70 @@
+from typing import Dict, List, Union
+
+import math
+import numpy as np
+import h5py
+
+def _intersect_channel_ids(channel_ids_list: List[List[int]]):
+    x = channel_ids_list[0]
+    for y in channel_ids_list:
+        x = np.intersect1d(x, y).tolist()
+    inds = []
+    for y in channel_ids_list:
+        a, inds_x, inds_y = np.intersect1d(x, y, return_indices=True)
+        inds.append(inds_y.tolist())
+    return x, inds
+
+def _get_unit_waveforms_from_list_from_snippets_h5(snippets_h5_path: str, unit_ids: List[int], max_num_events: int = None):
+    unit_waveforms_list = []
+    unit_waveforms_channel_ids_list = []
+    channel_locations_list = []
+    sampling_frequency_list = []
+    unit_spike_train_list = []
+    for unit_id in unit_ids:
+        unit_waveforms0, unit_waveforms_channel_ids0, channel_locations0, sampling_frequency0, unit_spike_train0 = get_unit_waveforms_from_snippets_h5(snippets_h5_path, unit_id, max_num_events=max_num_events)
+        unit_waveforms_list.append(unit_waveforms0)
+        unit_waveforms_channel_ids_list.append(unit_waveforms_channel_ids0)
+        channel_locations_list.append(channel_locations0)
+        sampling_frequency_list.append(sampling_frequency0)
+        unit_spike_train_list.append(unit_spike_train0)
+    intersection_channel_ids, inds = _intersect_channel_ids(unit_waveforms_channel_ids_list)
+    for i in range(len(unit_ids)):
+        unit_waveforms_list[i] = unit_waveforms_list[i][:, inds[i]]
+        unit_waveforms_channel_ids_list[i] = intersection_channel_ids
+        channel_locations_list[i] = channel_locations_list[i][inds[i]]
+    unit_waveforms = np.concatenate(unit_waveforms_list, axis=0)
+    unit_spike_train = np.concatenate(unit_spike_train_list)
+    return unit_waveforms, np.array(intersection_channel_ids), channel_locations_list[0], sampling_frequency_list[0], unit_spike_train
+
+def subsample_inds(n, m):
+    if m >= n:
+        return range(n)
+    incr = n / m
+    return [int(math.floor(i * incr)) for i in range(m)]
+
+def get_unit_waveforms_from_snippets_h5(snippets_h5_path: str, unit_id: Union[int, List[int]], max_num_events: int = None):
+    if type(unit_id) is list:
+        return _get_unit_waveforms_from_list_from_snippets_h5(snippets_h5_path, unit_id, max_num_events=max_num_events)
+    with h5py.File(snippets_h5_path, 'r') as f:
+        channel_ids = np.array(f.get('channel_ids'))
+        channel_locations = np.array(f.get(f'channel_locations'))
+        unit_spike_train = np.array(f.get(f'unit_spike_trains/{unit_id}'))
+        sampling_frequency = np.array(f.get('sampling_frequency'))[0].item()
+        if np.isnan(sampling_frequency):
+            print('WARNING: sampling frequency is nan. Using 30000 for now. Please correct the snippets file.')
+            sampling_frequency = 30000
+        unit_waveforms = np.array(f.get(f'unit_waveforms/{unit_id}/waveforms'))
+        unit_waveforms_channel_ids = np.array(f.get(f'unit_waveforms/{unit_id}/channel_ids'))
+
+        if max_num_events is not None:
+            if len(unit_spike_train) > max_num_events:
+                inds = subsample_inds(len(unit_spike_train), max_num_events)
+                unit_spike_train = unit_spike_train[inds]
+                unit_waveforms = unit_waveforms[inds]
+
+    channel_locations0 = []
+    for ch_id in unit_waveforms_channel_ids:
+        ind = np.where(channel_ids == ch_id)[0]
+        channel_locations0.append(channel_locations[ind, :].ravel().tolist())
+    
+    return unit_waveforms, unit_waveforms_channel_ids, np.array(channel_locations0), sampling_frequency, unit_spike_train

--- a/src/extensions/averagewaveforms/AverageWaveformsView/AverageWaveformView.tsx
+++ b/src/extensions/averagewaveforms/AverageWaveformsView/AverageWaveformView.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useMemo } from 'react';
 import { createCalculationPool, HitherJobStatusView, useHitherJob } from '../../common/hither';
 import { ActionItem, DividerItem } from '../../common/Toolbars';
-import { Recording, Sorting, SortingSelection, SortingSelectionDispatch } from '../../extensionInterface';
+import { applyMergesToUnit, Recording, Sorting, SortingSelection, SortingSelectionDispatch } from '../../extensionInterface';
 import WaveformWidget, { ElectrodeOpts } from './WaveformWidget';
 
 type PlotData = {
@@ -31,7 +31,7 @@ const AverageWaveformView: FunctionComponent<Props> = ({ sorting, recording, uni
         {
             sorting_object: sorting.sortingObject,
             recording_object: recording.recordingObject,
-            unit_id: unitId
+            unit_id: applyMergesToUnit(unitId, sorting.curation, selection.applyMerges)
         },
         {useClientCache: true, calculationPool}
     )

--- a/src/extensions/averagewaveforms/AverageWaveformsView/fetch_average_waveforms_2.py
+++ b/src/extensions/averagewaveforms/AverageWaveformsView/fetch_average_waveforms_2.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List, Union
 
 import os
 import hither as hi
@@ -23,36 +23,20 @@ def createjob_fetch_average_waveform_2(labbox, recording_object, sorting_object,
             unit_id=unit_id
         )
 
-@hi.function('fetch_average_waveform_2', '0.2.10')
+@hi.function('fetch_average_waveform_2', '0.2.14')
 @hi.container('docker://magland/labbox-ephys-processing:0.3.19')
 @hi.local_modules([os.getenv('LABBOX_EPHYS_PYTHON_MODULE_DIR')])
 @le.serialize
 def fetch_average_waveform_2(snippets_h5, unit_id):
     import h5py
     h5_path = ka.load_file(snippets_h5)
-    with h5py.File(h5_path, 'r') as f:
-        unit_ids = np.array(f.get('unit_ids'))
-        channel_ids = np.array(f.get('channel_ids'))
-        channel_locations = np.array(f.get(f'channel_locations'))
-        sampling_frequency = np.array(f.get('sampling_frequency'))[0].item()
-        if np.isnan(sampling_frequency):
-            print('WARNING: sampling frequency is nan. Using 30000 for now. Please correct the snippets file.')
-            sampling_frequency = 30000
-        unit_spike_train = np.array(f.get(f'unit_spike_trains/{unit_id}'))
-        unit_waveforms = np.array(f.get(f'unit_waveforms/{unit_id}/waveforms'))
-        unit_waveforms_channel_ids = np.array(f.get(f'unit_waveforms/{unit_id}/channel_ids'))
-
-        print(unit_waveforms_channel_ids)
+    unit_waveforms, unit_waveforms_channel_ids, channel_locations0, sampling_frequency, unit_spike_train = le.get_unit_waveforms_from_snippets_h5(h5_path, unit_id)
     
     average_waveform = np.mean(unit_waveforms, axis=0)
-    channel_locations0 = []
-    for ch_id in unit_waveforms_channel_ids:
-        ind = np.where(channel_ids == ch_id)[0]
-        channel_locations0.append(channel_locations[ind, :].ravel().tolist())
 
     return dict(
         average_waveform=average_waveform.astype(np.float32),
         channel_ids=unit_waveforms_channel_ids.astype(np.int32),
-        channel_locations=channel_locations0,
+        channel_locations=channel_locations0.astype(np.float32),
         sampling_frequency=sampling_frequency
     )

--- a/src/extensions/clusters/IndividualClustersView/IndividualClusterView.tsx
+++ b/src/extensions/clusters/IndividualClustersView/IndividualClusterView.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useCallback, useMemo } from 'react';
 import { createCalculationPool, HitherJobStatusView, useHitherJob } from '../../common/hither';
-import { Recording, Sorting, SortingSelection, SortingSelectionDispatch } from '../../extensionInterface';
+import { applyMergesToUnit, Recording, Sorting, SortingSelection, SortingSelectionDispatch } from '../../extensionInterface';
 import IndividualClusterWidget from './IndividualClusterWidget';
 
 type Props = {
@@ -27,7 +27,7 @@ const IndividualClusterView: FunctionComponent<Props> = ({ recording, sorting, s
         {
             recording_object: recording.recordingObject,
             sorting_object: sorting.sortingObject,
-            unit_id: unitId
+            unit_id: applyMergesToUnit(unitId, sorting.curation, selection.applyMerges)
         },
         {
             useClientCache: true,

--- a/src/extensions/clusters/clusters.py
+++ b/src/extensions/clusters/clusters.py
@@ -35,25 +35,27 @@ def subsample_inds(n, m):
     incr = n / m
     return [int(math.floor(i * incr)) for i in range(m)]
 
-@hi.function('individual_cluster_features', '0.1.3')
+@hi.function('individual_cluster_features', '0.1.4')
 @hi.container('docker://magland/labbox-ephys-processing:0.3.19')
 @hi.local_modules([os.getenv('LABBOX_EPHYS_PYTHON_MODULE_DIR')])
 @le.serialize
 def individual_cluster_features(snippets_h5, unit_id, max_num_events=1000):
     import h5py
     h5_path = ka.load_file(snippets_h5)
-    with h5py.File(h5_path, 'r') as f:
-        unit_ids = np.array(f.get('unit_ids'))
-        channel_ids = np.array(f.get('channel_ids'))
-        channel_locations = np.array(f.get(f'channel_locations'))
-        sampling_frequency = np.array(f.get('sampling_frequency'))[0].item()
-        unit_spike_train = np.array(f.get(f'unit_spike_trains/{unit_id}'))
-        unit_waveforms = np.array(f.get(f'unit_waveforms/{unit_id}/waveforms')) # L x M x T
-        unit_waveforms_channel_ids = np.array(f.get(f'unit_waveforms/{unit_id}/channel_ids'))
-        if len(unit_spike_train) > max_num_events:
-            inds = subsample_inds(len(unit_spike_train), max_num_events)
-            unit_spike_train = unit_spike_train[inds]
-            unit_waveforms = unit_waveforms[inds]
+    # with h5py.File(h5_path, 'r') as f:
+    #     unit_ids = np.array(f.get('unit_ids'))
+    #     channel_ids = np.array(f.get('channel_ids'))
+    #     channel_locations = np.array(f.get(f'channel_locations'))
+    #     sampling_frequency = np.array(f.get('sampling_frequency'))[0].item()
+    #     unit_spike_train = np.array(f.get(f'unit_spike_trains/{unit_id}'))
+    #     unit_waveforms = np.array(f.get(f'unit_waveforms/{unit_id}/waveforms')) # L x M x T
+    #     unit_waveforms_channel_ids = np.array(f.get(f'unit_waveforms/{unit_id}/channel_ids'))
+    #     if len(unit_spike_train) > max_num_events:
+    #         inds = subsample_inds(len(unit_spike_train), max_num_events)
+    #         unit_spike_train = unit_spike_train[inds]
+    #         unit_waveforms = unit_waveforms[inds]
+    
+    unit_waveforms, unit_waveforms_channel_ids, channel_locations0, sampling_frequency, unit_spike_train = le.get_unit_waveforms_from_snippets_h5(h5_path, unit_id, max_num_events=max_num_events)
     
     from sklearn.decomposition import PCA
     nf = 2 # number of features

--- a/src/extensions/common/SortingUnitPlotGrid.tsx
+++ b/src/extensions/common/SortingUnitPlotGrid.tsx
@@ -1,6 +1,6 @@
 import { Button, Grid } from '@material-ui/core';
 import React, { FunctionComponent, useCallback, useState } from 'react';
-import { Sorting, SortingInfo, SortingSelection, SortingSelectionDispatch } from '../extensionInterface';
+import { isMergeGroupRepresentative, Sorting, SortingInfo, SortingSelection, SortingSelectionDispatch } from '../extensionInterface';
 import { useSortingInfo } from './useSortingInfo';
 
 type Props = {
@@ -16,7 +16,9 @@ const SortingUnitPlotGrid: FunctionComponent<Props> = ({ sorting, selection, sel
     const sortingInfo: SortingInfo | undefined = useSortingInfo(sorting.sortingObject, sorting.recordingObject)
 
     const visibleUnitIds = selection.visibleUnitIds
-    let unit_ids: number[] = (sortingInfo ? sortingInfo.unit_ids : []).filter(uid => ((!visibleUnitIds) || (visibleUnitIds.includes(uid))));
+    let unit_ids: number[] = (sortingInfo ? sortingInfo.unit_ids : [])
+        .filter(uid => ((!visibleUnitIds) || (visibleUnitIds.includes(uid))))
+        .filter(uid => ((!selection.applyMerges) || (isMergeGroupRepresentative(uid, sorting.curation))))
     let showExpandButton = false;
     if (unit_ids.length > maxUnitsVisible) {
         unit_ids = unit_ids.slice(0, maxUnitsVisible);

--- a/src/extensions/common/useFetchCache.ts
+++ b/src/extensions/common/useFetchCache.ts
@@ -15,6 +15,10 @@ const initialFetchCacheState = {
     activeFetches: {}
 }
 
+type ClearAction = {
+    type: 'clear'
+}
+
 type StartFetchAction = {
     type: 'startFetch',
     queryHash: string
@@ -26,10 +30,13 @@ type SetDataAction = {
     data: any
 }
 
-type FetchCacheAction = StartFetchAction | SetDataAction
+type FetchCacheAction = ClearAction | StartFetchAction | SetDataAction
 
 const fetchCacheReducer = (state: FetchCacheState, action: FetchCacheAction): FetchCacheState => {
     switch(action.type) {
+        case 'clear': {
+            return initialFetchCacheState
+        }
         case 'startFetch': {
             return {
                 ...state,
@@ -64,8 +71,16 @@ const queryHash = <QueryType>(query: QueryType) => {
 
 const useFetchCache = <QueryType>(fetchFunction: (query: QueryType) => Promise<any>): FetchCache<QueryType> => {
     const [count, setCount] = useState(0)
+    const prevFetchFunction = useRef<(query: QueryType) => Promise<any>>(fetchFunction)
     const [state, dispatch] = useReducer(fetchCacheReducer, initialFetchCacheState)
     const queriesToFetch = useRef<{[key: string]: QueryType}>({})
+    useEffect(() => {
+        // clear whenever fetchFunctionHashChanged
+        if (fetchFunction !== prevFetchFunction.current) {
+            prevFetchFunction.current = fetchFunction
+            dispatch({type: 'clear'})
+        }
+    }, [fetchFunction])
     const get = useMemo(() => ((query: QueryType) => {
         const h = queryHash(query)
         const v = state.data[h]

--- a/src/extensions/common/useFetchCache.ts
+++ b/src/extensions/common/useFetchCache.ts
@@ -75,7 +75,7 @@ const useFetchCache = <QueryType>(fetchFunction: (query: QueryType) => Promise<a
     const [state, dispatch] = useReducer(fetchCacheReducer, initialFetchCacheState)
     const queriesToFetch = useRef<{[key: string]: QueryType}>({})
     useEffect(() => {
-        // clear whenever fetchFunctionHashChanged
+        // clear whenever fetchFunction has Changed
         if (fetchFunction !== prevFetchFunction.current) {
             prevFetchFunction.current = fetchFunction
             dispatch({type: 'clear'})

--- a/src/extensions/correlograms/Correlogram_ReactVis2.tsx
+++ b/src/extensions/correlograms/Correlogram_ReactVis2.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { VerticalBarSeries, XAxis, XYPlot, YAxis } from 'react-vis';
 import { createCalculationPool, HitherJobStatusView, useHitherJob } from '../common/hither';
-import { Sorting, SortingSelection, SortingSelectionDispatch } from '../extensionInterface';
+import { applyMergesToUnit, Sorting, SortingSelection, SortingSelectionDispatch } from '../extensionInterface';
 
 type PlotData = {
     bins: number[]
@@ -27,8 +27,8 @@ const Correlogram_rv2: FunctionComponent<Props> = ({ sorting, unitId1, unitId2, 
         'createjob_fetch_correlogram_plot_data',
         {
             sorting_object: sorting.sortingObject,
-            unit_x: unitId1,
-            unit_y: unitId2 !== undefined ? unitId2 : null
+            unit_x: applyMergesToUnit(unitId1, sorting.curation, selection.applyMerges),
+            unit_y: unitId2 !== undefined ? applyMergesToUnit(unitId2, sorting.curation, selection.applyMerges) : null
         },
         {useClientCache: false, calculationPool}
     )

--- a/src/extensions/mountainview/MVSortingView/CurationControl.tsx
+++ b/src/extensions/mountainview/MVSortingView/CurationControl.tsx
@@ -1,4 +1,4 @@
-import { Grid, Paper } from '@material-ui/core';
+import { Checkbox, Grid, Paper } from '@material-ui/core';
 import React, { FunctionComponent, useCallback, useMemo } from 'react';
 import sizeMe, { SizeMeProps } from 'react-sizeme';
 import { SortingCurationWorkspaceAction } from '../../common/workspaceReducer';
@@ -62,6 +62,10 @@ const CurationControl: FunctionComponent<Props & SizeMeProps> = ({ sortingId, se
             unitIds: selectedUnitIds
         })
     }, [curationDispatch, selectedUnitIds, sortingId])
+
+    const handleToggleApplyMerges = useCallback(() => {
+        selectionDispatch({type: 'ToggleApplyMerges', curation})
+    }, [selectionDispatch, curation])
 
     type LabelRecord = {
         label: string,
@@ -139,6 +143,9 @@ const CurationControl: FunctionComponent<Props & SizeMeProps> = ({ sortingId, se
                 {
                     (selectedUnitIds.length > 0 && unitsAreInMergeGroups(selectedUnitIds)) && <button key="unmerge" onClick={handleUnmergeSelected}>Unmerge units: {selectedUnitIds.join(', ')}</button>
                 }
+                <span style={{whiteSpace: 'nowrap'}}>
+                    <Checkbox checked={selection.applyMerges || false} onClick={handleToggleApplyMerges}/> Apply merges
+                </span>
             </Paper>
         </div>
     )

--- a/src/extensions/snippets/snippets.py
+++ b/src/extensions/snippets/snippets.py
@@ -28,44 +28,41 @@ def createjob_get_sorting_unit_snippets(labbox, recording_object, sorting_object
             max_num_snippets=max_num_snippets
         )
 
-@hi.function('get_sorting_unit_snippets', '0.1.7')
+@hi.function('get_sorting_unit_snippets', '0.1.8')
 @hi.container('docker://magland/labbox-ephys-processing:0.3.19')
 @hi.local_modules([os.getenv('LABBOX_EPHYS_PYTHON_MODULE_DIR')])
 @le.serialize
 def get_sorting_unit_snippets(snippets_h5, unit_id, time_range, max_num_snippets):
     import h5py
     h5_path = ka.load_file(snippets_h5)
-    with h5py.File(h5_path, 'r') as f:
-        unit_ids = np.array(f.get('unit_ids'))
-        channel_ids = np.array(f.get('channel_ids'))
-        channel_locations = np.array(f.get(f'channel_locations'))
-        sampling_frequency = np.array(f.get('sampling_frequency'))[0].item()
-        if np.isnan(sampling_frequency):
-            print('WARNING: sampling frequency is nan. Using 30000 for now. Please correct the snippets file.')
-            sampling_frequency = 30000
-        unit_spike_train = np.array(f.get(f'unit_spike_trains/{unit_id}'))
-        unit_waveforms = np.array(f.get(f'unit_waveforms/{unit_id}/waveforms'))
-        unit_waveforms_channel_ids = np.array(f.get(f'unit_waveforms/{unit_id}/channel_ids'))
-        print(unit_waveforms_channel_ids)
+    # with h5py.File(h5_path, 'r') as f:
+    #     unit_ids = np.array(f.get('unit_ids'))
+    #     channel_ids = np.array(f.get('channel_ids'))
+    #     channel_locations = np.array(f.get(f'channel_locations'))
+    #     sampling_frequency = np.array(f.get('sampling_frequency'))[0].item()
+    #     if np.isnan(sampling_frequency):
+    #         print('WARNING: sampling frequency is nan. Using 30000 for now. Please correct the snippets file.')
+    #         sampling_frequency = 30000
+    #     unit_spike_train = np.array(f.get(f'unit_spike_trains/{unit_id}'))
+    #     unit_waveforms = np.array(f.get(f'unit_waveforms/{unit_id}/waveforms'))
+    #     unit_waveforms_channel_ids = np.array(f.get(f'unit_waveforms/{unit_id}/channel_ids'))
+    #     print(unit_waveforms_channel_ids)
+    unit_waveforms, unit_waveforms_channel_ids, channel_locations0, sampling_frequency, unit_spike_train = le.get_unit_waveforms_from_snippets_h5(h5_path, unit_id)
     
     snippets = [
         {
             'index': j,
             'unitId': unit_id,
-            'waveform': unit_waveforms[j, :, :].astype(np.float32),
+            'waveform': unit_waveforms[j].astype(np.float32),
             'timepoint': float(unit_spike_train[j])
         }
         for j in range(unit_waveforms.shape[0])
+        if time_range['min'] <= unit_spike_train[j] and unit_spike_train[j] < time_range['max']
     ]
-    snippets = [s for s in snippets if time_range['min'] <= s['timepoint'] and s['timepoint'] < time_range['max']]
-    channel_locations0 = []
-    for ch_id in unit_waveforms_channel_ids:
-        ind = np.where(channel_ids == ch_id)[0]
-        channel_locations0.append(channel_locations[ind, :].ravel().tolist())
 
     return dict(
         channel_ids=unit_waveforms_channel_ids.astype(np.int32),
-        channel_locations=channel_locations0,
+        channel_locations=channel_locations0.astype(np.float32),
         sampling_frequency=sampling_frequency,
         snippets=snippets[:max_num_snippets]
     )
@@ -86,31 +83,32 @@ def createjob_get_sorting_unit_info(labbox, recording_object, sorting_object, un
             unit_id=unit_id
         )
 
-@hi.function('get_sorting_unit_info', '0.1.0')
+@hi.function('get_sorting_unit_info', '0.1.1')
 @hi.container('docker://magland/labbox-ephys-processing:0.3.19')
 @hi.local_modules([os.getenv('LABBOX_EPHYS_PYTHON_MODULE_DIR')])
 @le.serialize
 def get_sorting_unit_info(snippets_h5, unit_id):
     import h5py
     h5_path = ka.load_file(snippets_h5)
-    with h5py.File(h5_path, 'r') as f:
-        unit_ids = np.array(f.get('unit_ids'))
-        channel_ids = np.array(f.get('channel_ids'))
-        channel_locations = np.array(f.get(f'channel_locations'))
-        sampling_frequency = np.array(f.get('sampling_frequency'))[0].item()
-        if np.isnan(sampling_frequency):
-            print('WARNING: sampling frequency is nan. Using 30000 for now. Please correct the snippets file.')
-            sampling_frequency = 30000
-        unit_waveforms_channel_ids = np.array(f.get(f'unit_waveforms/{unit_id}/channel_ids'))
-        print(unit_waveforms_channel_ids)
+    # with h5py.File(h5_path, 'r') as f:
+    #     unit_ids = np.array(f.get('unit_ids'))
+    #     channel_ids = np.array(f.get('channel_ids'))
+    #     channel_locations = np.array(f.get(f'channel_locations'))
+    #     sampling_frequency = np.array(f.get('sampling_frequency'))[0].item()
+    #     if np.isnan(sampling_frequency):
+    #         print('WARNING: sampling frequency is nan. Using 30000 for now. Please correct the snippets file.')
+    #         sampling_frequency = 30000
+    #     unit_waveforms_channel_ids = np.array(f.get(f'unit_waveforms/{unit_id}/channel_ids'))
+    #     print(unit_waveforms_channel_ids)
+    unit_waveforms, unit_waveforms_channel_ids, channel_locations0, sampling_frequency, unit_spike_train = le.get_unit_waveforms_from_snippets_h5(h5_path, unit_id)
     
-    channel_locations0 = []
+    channel_locations_2 = []
     for ch_id in unit_waveforms_channel_ids:
-        ind = np.where(channel_ids == ch_id)[0]
-        channel_locations0.append(channel_locations[ind, :].ravel().tolist())
+        ind = np.where(unit_waveforms_channel_ids == ch_id)[0]
+        channel_locations_2.append(channel_locations0[ind].ravel().tolist())
 
     return dict(
         channel_ids=unit_waveforms_channel_ids.astype(np.int32),
-        channel_locations=channel_locations0,
+        channel_locations=channel_locations_2,
         sampling_frequency=sampling_frequency
     )

--- a/src/extensions/spikeamplitudes/SpikeAmplitudesView/SelectUnitsWidget.tsx
+++ b/src/extensions/spikeamplitudes/SpikeAmplitudesView/SelectUnitsWidget.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { useSortingInfo } from '../../common/useSortingInfo';
-import { Sorting, SortingSelection, SortingSelectionDispatch } from '../../extensionInterface';
+import { isMergeGroupRepresentative, Sorting, SortingSelection, SortingSelectionDispatch } from '../../extensionInterface';
 import UnitsTable from '../../unitstable/Units/UnitsTable';
 
 type Props = {
@@ -12,9 +12,11 @@ type Props = {
 const SelectUnitsWidget: FunctionComponent<Props> = ({ sorting, selection, selectionDispatch }) => {
     const sortingInfo = useSortingInfo(sorting.sortingObject, sorting.recordingObject)
     if (!sortingInfo) return <div>No sorting info</div>
+    const unitIds = (sortingInfo?.unit_ids || [])
+        .filter(uid => ((!selection.applyMerges) || (isMergeGroupRepresentative(uid, sorting.curation))))
     return (
         <UnitsTable
-            units={sortingInfo?.unit_ids}
+            units={unitIds}
             {...{selection, selectionDispatch, sorting}}
         />
     )

--- a/src/extensions/spikeamplitudes/SpikeAmplitudesView/SpikeAmplitudesPanel.ts
+++ b/src/extensions/spikeamplitudes/SpikeAmplitudesView/SpikeAmplitudesPanel.ts
@@ -11,9 +11,11 @@ const colorList = [
     'green',
     'red',
     'orange',
-    'purple'
+    'purple',
+    'cyan'
 ]
-const colorForUnitId = (unitId: number) => {
+const colorForUnitId = (unitId: number | number[]): string => {
+    if (Array.isArray(unitId)) return colorForUnitId(Math.min(...unitId))
     while (unitId < 0) unitId += colorList.length
     return colorList[unitId % colorList.length]
 } 
@@ -27,7 +29,7 @@ class SpikeAmplitudesPanel {
     _globalAmplitudeRange: {min: number, max: number} | null = null
     _includeZero = true
     _amplitudes: number[] | undefined = undefined
-    constructor(private args: {spikeAmplitudesData: SpikeAmplitudesData | null, recording: Recording, sorting: Sorting, unitId: number, hither: HitherInterface}) {
+    constructor(private args: {spikeAmplitudesData: SpikeAmplitudesData | null, recording: Recording, sorting: Sorting, unitId: number | number[], hither: HitherInterface}) {
     }
     setTimeRange(timeRange: {min: number, max: number}) {
         this._timeRange = timeRange

--- a/src/extensions/spikeamplitudes/SpikeAmplitudesView/SpikeAmplitudesTimeWidget.tsx
+++ b/src/extensions/spikeamplitudes/SpikeAmplitudesView/SpikeAmplitudesTimeWidget.tsx
@@ -4,7 +4,7 @@ import useBufferedDispatch from '../../common/useBufferedDispatch';
 import { useRecordingInfo } from '../../common/useRecordingInfo';
 import { useSortingInfo } from '../../common/useSortingInfo';
 import { getArrayMax, getArrayMin } from '../../common/Utility';
-import { Recording, Sorting, SortingSelection, SortingSelectionDispatch, sortingSelectionReducer } from '../../extensionInterface';
+import { applyMergesToUnit, Recording, Sorting, SortingSelection, SortingSelectionDispatch, sortingSelectionReducer } from '../../extensionInterface';
 import TimeWidgetNew from '../../timeseries/TimeWidgetNew/TimeWidgetNew';
 import SpikeAmplitudesPanel, { combinePanels } from './SpikeAmplitudesPanel';
 import { SpikeAmplitudesData } from './useSpikeAmplitudesData';
@@ -35,8 +35,9 @@ const SpikeAmplitudesTimeWidget: FunctionComponent<Props> = ({ spikeAmplitudesDa
         const allMaxs: number[] = []
 
         unitIds.forEach(unitId => {
-            const p = new SpikeAmplitudesPanel({spikeAmplitudesData, recording, sorting, unitId, hither})
-            const amps = spikeAmplitudesData.getSpikeAmplitudes(unitId)
+            const uid = applyMergesToUnit(unitId, sorting.curation, selection.applyMerges)
+            const p = new SpikeAmplitudesPanel({spikeAmplitudesData, recording, sorting, unitId: uid, hither})
+            const amps = spikeAmplitudesData.getSpikeAmplitudes(uid)
             if (amps) {
                 allMins.push(amps.minAmp)
                 allMaxs.push(amps.maxAmp)

--- a/src/extensions/spikeamplitudes/SpikeAmplitudesView/useSpikeAmplitudesData.ts
+++ b/src/extensions/spikeamplitudes/SpikeAmplitudesView/useSpikeAmplitudesData.ts
@@ -4,17 +4,17 @@ import useFetchCache from "../../common/useFetchCache"
 import { getArrayMax, getArrayMin } from '../../common/Utility'
 
 export type SpikeAmplitudesData = {
-    getSpikeAmplitudes: (unitId: number) => {timepoints: number[], amplitudes: number[], minAmp: number, maxAmp: number} | undefined | null
+    getSpikeAmplitudes: (unitId: number | number[]) => {timepoints: number[], amplitudes: number[], minAmp: number, maxAmp: number} | undefined | null
 }
 
 type SpikeAmplitudesDataQuery = {
     type: 'spikeAmplitudes',
-    unitId: number
+    unitId: number | number[]
 }
 
 const calculationPool = createCalculationPool({maxSimultaneous: 6})
 
-const fetchSpikeAmplitudes = async ({hither, recordingObject, sortingObject, unitId}: {hither: HitherInterface, recordingObject: any, sortingObject: any, unitId: number}) => {
+const fetchSpikeAmplitudes = async ({hither, recordingObject, sortingObject, unitId}: {hither: HitherInterface, recordingObject: any, sortingObject: any, unitId: number | number[]}) => {
     const result = await hither.createHitherJob(
         'createjob_fetch_spike_amplitudes',
         {
@@ -49,7 +49,7 @@ const useSpikeAmplitudesData = (recordingObject: any, sortingObject: any): Spike
     }), [hither, recordingObject, sortingObject])
     const data = useFetchCache<SpikeAmplitudesDataQuery>(fetch)
 
-    const getSpikeAmplitudes = useMemo(() => ((unitId: number): {timepoints: number[], amplitudes: number[], minAmp: number, maxAmp: number} | undefined => {
+    const getSpikeAmplitudes = useMemo(() => ((unitId: number | number[]): {timepoints: number[], amplitudes: number[], minAmp: number, maxAmp: number} | undefined => {
         return data.get({type: 'spikeAmplitudes', unitId})
     }), [data])
 

--- a/src/extensions/spikeamplitudes/spikeamplitudes.py
+++ b/src/extensions/spikeamplitudes/spikeamplitudes.py
@@ -30,23 +30,32 @@ def _compute_peak_channel_index_from_average_waveform(average_waveform):
     peak_channel_index = np.argmax(channel_amplitudes)
     return peak_channel_index
 
-@hi.function('fetch_spike_amplitudes', '0.1.4')
+@hi.function('fetch_spike_amplitudes', '0.1.6')
 @hi.container('docker://magland/labbox-ephys-processing:0.3.19')
 @hi.local_modules([os.getenv('LABBOX_EPHYS_PYTHON_MODULE_DIR')])
 @le.serialize
 def fetch_spike_amplitudes(snippets_h5, unit_id):
     import h5py
     h5_path = ka.load_file(snippets_h5)
-    with h5py.File(h5_path, 'r') as f:
-        unit_spike_train = np.array(f.get(f'unit_spike_trains/{unit_id}'))
-        unit_waveforms = np.array(f.get(f'unit_waveforms/{unit_id}/waveforms'))
-        average_waveform = np.mean(unit_waveforms, axis=0)
-        peak_channel_index = _compute_peak_channel_index_from_average_waveform(average_waveform)
-        maxs = [np.max(unit_waveforms[i][peak_channel_index, :]) for i in range(unit_waveforms.shape[0])]
-        mins = [np.min(unit_waveforms[i][peak_channel_index, :]) for i in range(unit_waveforms.shape[0])]
-        peak_amplitudes = np.array([maxs[i] - mins[i] for i in range(len(mins))])
+    # with h5py.File(h5_path, 'r') as f:
+    #     unit_spike_train = np.array(f.get(f'unit_spike_trains/{unit_id}'))
+    #     unit_waveforms = np.array(f.get(f'unit_waveforms/{unit_id}/waveforms'))    
+        
+    unit_waveforms, unit_waveforms_channel_ids, channel_locations0, sampling_frequency, unit_spike_train = le.get_unit_waveforms_from_snippets_h5(h5_path, unit_id)
+    average_waveform = np.mean(unit_waveforms, axis=0)
+    peak_channel_index = _compute_peak_channel_index_from_average_waveform(average_waveform)
+    maxs = [np.max(unit_waveforms[i][peak_channel_index, :]) for i in range(unit_waveforms.shape[0])]
+    mins = [np.min(unit_waveforms[i][peak_channel_index, :]) for i in range(unit_waveforms.shape[0])]
+    peak_amplitudes = np.array([maxs[i] - mins[i] for i in range(len(mins))])
+
+    timepoints = unit_spike_train.astype(np.float32)
+    amplitudes = peak_amplitudes.astype(np.float32)
+
+    sort_inds = np.argsort(timepoints)
+    timepoints = timepoints[sort_inds]
+    amplitudes = amplitudes[sort_inds]
     
     return dict(
-        timepoints=unit_spike_train.astype(np.float32),
-        amplitudes=peak_amplitudes.astype(np.float32)
+        timepoints=timepoints,
+        amplitudes=amplitudes
     )

--- a/src/extensions/unitstable/Units/UnitsTable.tsx
+++ b/src/extensions/unitstable/Units/UnitsTable.tsx
@@ -90,7 +90,7 @@ const UnitsTable: FunctionComponent<Props> = (props) => {
     rows.forEach(row => {
         const unitId = Number(row.rowId)
         row.data['_unit_id'] = {
-            value: {unitId, mergeGroup: mergeGroupForUnitId(unitId, sorting)},
+            value: {unitId, mergeGroup: mergeGroupForUnitId(unitId, sorting.curation)},
             sortValue: unitId
         }
     })


### PR DESCRIPTION
An option to 'apply merges'. When checked, the various plots (autocor, avg waveforms, spike amplitudes, etc) respect the merge decisions.

![image](https://user-images.githubusercontent.com/3679296/107647887-a4e7d000-6c49-11eb-85ed-4e53015daad5.png)

This was accomplished by updating the various python processing functions to allow `unit_id` to be either a single number of a list of numbers. In the case of a list, the python processing merges them together. The list is determined on the client side based on the curation's mergeGroups. See the `applyMergesToUnit` function.

Right now, the metrics in the units table are not affected by the merge. Need to think about how best to do this since we don't necessarily want to recompute this every time a merge is made.