### PR TITLE
Change name of spike train checking function in nwbextractors.py

### DIFF
--- a/src/python/labbox_ephys/extractors/nwbextractors/nwbextractors.py
+++ b/src/python/labbox_ephys/extractors/nwbextractors/nwbextractors.py
@@ -9,7 +9,7 @@ from typing import Union
 import warnings
 
 import spikeextractors as se
-from spikeextractors.extraction_tools import check_get_traces_args, check_valid_unit_id
+from spikeextractors.extraction_tools import check_get_traces_args, check_get_unit_spike_train
 
 try:
     import pynwb
@@ -1060,7 +1060,7 @@ class NwbSortingExtractor(se.SortingExtractor):
             unit_ids = [int(i) for i in nwbfile.units.id[:]]
         return unit_ids
 
-    @check_valid_unit_id
+    @check_get_unit_spike_train
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:


### PR DESCRIPTION
`spikeextractors` changed the name of the function that checks the validity of `get_unit_spike_train` calls from `check_valid_unit_id` to `check_get_unit_spike_train`. This commit reflects this change.